### PR TITLE
Correct use of {{ .Hugo.Generator }}

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
 <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
-<meta name="generator" content="{{ .Hugo.Generator }}" />
+{{ .Hugo.Generator }}
 <title>{{ .Site.Title }}</title>
 {{ "<!-- Bootstrap Core CSS -->" | safeHTML }}
 <link href="{{ .Site.BaseURL }}css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
Thank you for including the `{{ .Hugo.Generator }}` tag!  :+1:

However, as you may not know, `{{ .Hugo.Generator }}` already includes the entire meta tag, not just the program name and version, so here is a PR to fix that.  :-)
