### PR TITLE
Update config.toml to point to 'agency' theme

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,7 +2,7 @@
 baseurl = "http://replace-this-with-your-hugo-site.com/"
 languageCode = "en-us"
 title = "Hugo Agency Theme"
-theme = "hugo-agency-theme"
+theme = "agency"
 
 
 [params]


### PR DESCRIPTION
Using the procedure in the [hugoThemes README](https://github.com/spf13/hugoThemes/blob/master/README.md), this theme appears to be under the name 'agency' rather than 'hugo-agency-theme'. 

At the same time, the [agency README](https://github.com/digitalcraftsman/hugo-agency-theme/blob/master/README.md) suggests pulling this exampleSite's config.toml which points to what would be a nonexistent theme due to the move/rename.
