### PR TITLE
add plural rows

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -57,21 +57,22 @@ theme = "hugo-agency-theme"
 		title = "Services"
 		subtitle = "Lorem ipsum dolor sit amet consectetur."
 
-		[[params.services.list]]
-			icon = "fa-shopping-cart"
-			title = "E-Commerce"
-			description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+        [[params.services.row]]
 
-		[[params.services.list]]
-			icon = "fa-laptop"
-			title = "Responsive Design"
-			description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+            [[params.services.row.list]]
+                icon = "fa-shopping-cart"
+                title = "E-Commerce"
+                description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
 
-		[[params.services.list]]
-			icon = "fa-lock"
-			title = "Web"
-			description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+            [[params.services.row.list]]
+                icon = "fa-laptop"
+                title = "Responsive Design"
+                description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
 
+            [[params.services.row.list]]
+                icon = "fa-lock"
+                title = "Web"
+                description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
 
 	# Portfolio section
 	[params.portfolio]

--- a/layouts/partials/services.html
+++ b/layouts/partials/services.html
@@ -7,8 +7,10 @@
                 <h3 class="section-subheading text-muted">{{ with .Site.Params.services.subtitle }}{{ . | markdownify }}{{ end }}</h3>
             </div>
         </div>
+
+        {{ range .Site.Params.services.row }}
         <div class="row text-center">
-            {{ range .Site.Params.services.list }}
+            {{ range .list }}
             <div class="col-md-4">
                 <span class="fa-stack fa-4x">
                     <i class="fa fa-circle fa-stack-2x text-primary"></i>
@@ -19,5 +21,7 @@
             </div>
             {{ end }}
         </div>
+        {{ end }}
+
     </div>
 </section>


### PR DESCRIPTION
I tried to add a row in the services part of config.toml, but the layout looks like weird.
e.g) the list is declared 4 times

```
[[params.services.list]]
icon = "fa-shopping-cart"
title = "E-Commerce"
description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."

[[params.services.list]]
...
[[params.services.list]]
...
[[params.services.list]]
...
```

so I included the list into the row. I think this is flexible.
