### PR TITLE
Mark brand as HTML

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -9,7 +9,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand page-scroll" href="#page-top">{{ with .Site.Params.navigation.brand }}{{ . }}{{ end }}</a>
+            <a class="navbar-brand page-scroll" href="#page-top">{{ with .Site.Params.navigation.brand }}{{ . | safeHTML }}{{ end }}</a>
         </div>
         {{ "<!-- Collect the nav links, forms, and other content for toggling -->" | safeHTML }}
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">


### PR DESCRIPTION
To allow HTML; custom image icon, <strong> etc.

There are probably other fields that need similar; but the about section may
be better off with a `markdownify` instead? Not sure.
