### PR TITLE
Show only non empty fields in contact form

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -229,6 +229,12 @@ googleAnalytics = ""
     subtitle  = "Lorem ipsum dolor sit amet consectetur."
     buttonText = "Send message"
 
+    # It is possible to substitute formspring with other providers
+    # as an example the mailout plugin from caddy.
+    # Provide the post URL for the form and depending on the provider
+    # add some custom JS script to finish the implementation.
+    # postURL = "https://example.com/mailout/"
+
     # 'warning' defines error messages for invalid inputs
     [params.contact.form.name]
       text = "Your Name *"

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -16,7 +16,12 @@
     </div>
     <div class="row">
       <div class="col-lg-12">
+        {{ if not .Site.Params.contact.postURL }}
         <form  action="//formspree.io/{{ with .Site.Params.email }}{{.}}{{ end }}" method="POST" name="sentMessage" id="contactForm" novalidate>
+        {{ else }}
+        <form  action="{{ .Site.Params.contact.postURL }}" method="POST" name="sentMessage" id="contactForm" novalidate>
+        {{ end }}
+
           <div class="row">
             <div class="col-md-6">
 

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -3,8 +3,15 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-12 text-center">
-        <h2 class="section-heading">{{ with .Site.Params.contact.title }}{{ . | markdownify }}{{ end }}</h2>
-        <h3 class="section-subheading text-muted">{{ with .Site.Params.contact.subtitle }}{{ . | markdownify }}{{ end }}</h3>
+
+        {{ with .Site.Params.contact.title }}
+        <h2 class="section-heading">{{ . | markdownify }}</h2>
+        {{ end }}
+
+        {{ with .Site.Params.contact.subtitle }}
+        <h3 class="section-subheading text-muted">{{ . | markdownify }}</h3>
+        {{ end }}
+
       </div>
     </div>
     <div class="row">
@@ -12,24 +19,37 @@
         <form  action="//formspree.io/{{ with .Site.Params.email }}{{.}}{{ end }}" method="POST" name="sentMessage" id="contactForm" novalidate>
           <div class="row">
             <div class="col-md-6">
+
+              {{ with .Site.Params.contact.form.name }}
               <div class="form-group">
-                <input type="text" class="form-control" placeholder="{{ with .Site.Params.contact.form.name.text }}{{ .  | markdownify }}{{ end }}" name="name" required data-validation-required-message="{{ with .Site.Params.contact.form.name.warning }}{{ . | markdownify}}{{ end }}">
+                <input type="text" class="form-control" placeholder="{{ with .text }}{{ .  | markdownify }}{{ end }}" name="name" required data-validation-required-message="{{ with .warning }}{{ . | markdownify}}{{ end }}">
                 <p class="help-block text-danger"></p>
               </div>
+              {{ end }}
+
+              {{ with .Site.Params.contact.form.email }}
               <div class="form-group">
-                <input type="email" class="form-control" placeholder="{{ with .Site.Params.contact.form.email.text }}{{ . | markdownify }}{{ end }}" name="email" required data-validation-required-message="{{ with .Site.Params.contact.form.email.warning }}{{ . | markdownify }}{{ end }}">
+                <input type="email" class="form-control" placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}" name="email" required data-validation-required-message="{{ with .warning }}{{ . | markdownify }}{{ end }}">
                 <p class="help-block text-danger"></p>
               </div>
+              {{ end }}
+
+              {{ with .Site.Params.contact.form.phone }}
               <div class="form-group">
-                <input type="tel" class="form-control" placeholder="{{ with .Site.Params.contact.form.phone.text }}{{ . | markdownify }}{{ end }}" name="phone" required data-validation-required-message="{{ with .Site.Params.contact.form.phone.warning }}{{ . | markdownify }}{{ end }}">
+                <input type="tel" class="form-control" placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}" name="phone" required data-validation-required-message="{{ with .warning }}{{ . | markdownify }}{{ end }}">
                 <p class="help-block text-danger"></p>
               </div>
             </div>
             <div class="col-md-6">
+              {{ end }}
+
+              {{ with .Site.Params.contact.form.message }}
               <div class="form-group">
-                <textarea class="form-control" placeholder="{{ with .Site.Params.contact.form.message.text }}{{ . | markdownify }}{{ end }}" name="message" required data-validation-required-message="{{ with .Site.Params.contact.form.message.warning }}{{ . | markdownify }}{{ end }}"></textarea>
+                <textarea class="form-control" placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}" name="message" required data-validation-required-message="{{ with .warning }}{{ . | markdownify }}{{ end }}"></textarea>
                 <p class="help-block text-danger"></p>
               </div>
+              {{ end }}
+
             </div>
             <div class="clearfix"></div>
             <div class="col-lg-12 text-center">


### PR DESCRIPTION
Enable removal of contact form fields

Simplify contact form code and remove unused items from output.
Also add option for other providers.

Fixes: #20 #35 