### PR TITLE
Add url to services

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -97,16 +97,19 @@ googleAnalytics = ""
       icon = "fa-shopping-cart"
       title = "E-Commerce"
       description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+      url = "#"
 
     [[params.services.row.list]]
       icon = "fa-laptop"
       title = "Responsive Design"
       description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+      url = "#"
 
     [[params.services.row.list]]
       icon = "fa-lock"
       title = "Web"
       description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+      url = "#"
 
   # Portfolio section
   [params.portfolio]

--- a/layouts/partials/services.html
+++ b/layouts/partials/services.html
@@ -15,7 +15,7 @@
               <i class="fa fa-circle fa-stack-2x text-primary"></i>
               <i class="fa {{ .icon }} fa-stack-1x fa-inverse"></i>
             </span>
-            <h4 class="service-heading">{{ .title | markdownify }}</h4>
+            <h4 class="service-heading">{{ if .url }}<a href="{{ .url }}">{{ .title | markdownify }}</a>{{ else }}{{ .title | markdownify }}{{ end }}</h4>
             <p class="text-muted">{{ .description | markdownify }}</p>
           </div>
         {{ end }}


### PR DESCRIPTION
If url is set on a service item, enable clickable link.
If none is set, just show the title.

Fixes: #19