### PR TITLE
Make centering optional to preserve compatibility

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -236,6 +236,8 @@ googleAnalytics = ""
   # Contact section
   [params.contact]
     enable = true
+    # Possibility to center items
+    # center = true
     title = "Contact us"
     subtitle  = "Lorem ipsum dolor sit amet consectetur."
     buttonText = "Send message"

--- a/layouts/partials/team.html
+++ b/layouts/partials/team.html
@@ -7,7 +7,7 @@
         <h3 class="section-subheading text-mutedwith ">{{ with .Site.Params.team.subtitle }}{{ . | markdownify }}{{ end }}</h3>
       </div>
     </div>
-    <div class="row flexbox">
+    <div class="row flexbox{{ if .Site.Params.team.center }} flexbox-center{{ end }}">
       {{ range .Site.Params.team.members }}
         <div class="col-sm-4 col">
           <div class="team-member">

--- a/static/css/agency.css
+++ b/static/css/agency.css
@@ -635,8 +635,12 @@ section h3.section-subheading {
   display: flex;
   -webkit-flex-flow: row wrap;
   flex-flow: row wrap;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: stretch;
+}
+
+.flexbox-center {
+  justify-content: center;
 }
 
 .team-member {


### PR DESCRIPTION
I think preserving the current design and enabling centering on demand is the better choice.

Sorry for not seeing this solution on the first PR.