### PR TITLE
Fix post success callback usage

### DIFF
--- a/static/js/agency.js
+++ b/static/js/agency.js
@@ -48,15 +48,15 @@ $('.navbar-collapse ul li a').click(function() {
 
 // Async contact form
 $('form[id=contactForm]').submit(function(){
-  $.post($(this).attr('action'), $(this).serialize(), function(res){
+  $.post($(this).attr('action'), $(this).serialize(), function(data, textStatus, jqXHR){
     $('form[id=contactForm] #success').hide();
     $('form[id=contactForm] #error').hide();
-    if (res.code == "200")
+    if (jqXHR.status == 200) {
       $('form[id=contactForm] #success').show();
-    }).fail(function(){
-    $('form[id=contactForm] #success').hide();
-    $('form[id=contactForm] #error').hide();
-    $('form[id=contactForm] #error').show();
+    }}, 'json').fail(function(){
+      $('form[id=contactForm] #success').hide();
+      $('form[id=contactForm] #error').hide();
+      $('form[id=contactForm] #error').show();
   });
   return false;
 });


### PR DESCRIPTION
Fixes #83 . The post success callback function's parameters weren't being used properly. The "If" from line 54 now works, and the success message is correctly displayed.
![image](https://user-images.githubusercontent.com/6942459/29008517-d5272f36-7aee-11e7-9f5c-8213e9d5e231.png)
