### PR TITLE
Add a title tag to the footer icons

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -302,14 +302,17 @@ She worked at Pied Piper for years until they went belly up."""
     [[params.footer.social]]
       icon = "fa-twitter"
       link = "#"
+      title = "Twitter"
 
     [[params.footer.social]]
       icon = "fa-facebook"
       link = "#"
+      title = "Facebook"
 
     [[params.footer.social]]
       icon = "fa-linkedin"
       link = "#"
+      title = "LinkedIn"
 
     [[params.footer.quicklinks]]
       text = "Privacy Policy"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
         <ul class="list-inline social-buttons">
 
           {{ range .Site.Params.footer.social }}
-            <li><a href="{{ .link }}"><i class="fa {{ .icon }}"></i></a></li>
+            <li><a href="{{ .link }}" title="{{ .title }}"><i class="fa {{ .icon }}"></i></a></li>
           {{ end }}
 
         </ul>


### PR DESCRIPTION
When you have more of these icons the chance grows that users don't recognise the icon. This helps a bit.